### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Returns skin data as a SkinJSON to help you develop a [MediaWiki skin](https://w
 wfLoadSkin('SkinJson');
 ```
 * Navigate to the page you want to debug and add `?useskin=skinjson` to the URL e.g. http://localhost:8888/w/index.php/Main_page?useskin=skinjson
-* Install a Chrome or Firefox extension for prettifying JSON to allow exploration of the data.
 
 # Skins that extend SkinMustache
 


### PR DESCRIPTION
Remove the suggestion to "Install a Chrome or Firefox extension for prettifying JSON to allow exploration of the data." since the json_encode should return with the JSON_PRETTY_PRINT option.