### PR TITLE
Make score info available as a hover card instead of HTML title tooltip

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -31,6 +31,7 @@
 			"es6": true,
 			"dependencies": [ "mediawiki.user" ],
 			"scripts": [ "skinValidate.js" ],
+			"styles": [ "skinValidate.less" ],
 			"targets": [ "desktop", "mobile" ]
 		},
 		"skins.skinjson.debug.styles": {

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -83,23 +83,31 @@ $(function () {
         });
         const grade = scoreToGrade( score, r );
 
-        let container = document.querySelector( '.skinjson-scores' );
-        if ( !container ) {
-            container = document.createElement( 'div' );
-            container.classList.add( 'skinjson-scores' );
-            document.body.appendChild( container );
-        }
+        const createContainer = () => {
+            const el = document.createElement( 'div' );
+            el.classList.add( 'skinjson-scores' );
+            document.body.appendChild( el );
+            return el;
+        };
+        const container = document.querySelector( '.skinjson-scores' ) ?? createContainer();
 
-        $( '<div>' ).addClass(
-            `skinjson-score skinjson-score-${grade.label}`
-        ).attr(
-            'title', 
-            improvements.length ?
-                `Scoring by SkinJSON.\nPossible improvements for ${who}:\n${improvements.join('\n')}` :
-                `Skin passed all tests for ${who}`
-        ).text( grade.name ).on( 'click', (ev) => {
+        // NOTE: Maybe this should be put into some kind of template,
+        // maybe HTML template tag or Mustache or template literals
+        const scorebox = document.createElement( 'div' );
+        scorebox.classList.add( 'skinjson-score', `skinjson-score-${grade.label}` );
+        scorebox.textContent = grade.name;
+
+        const scoreinfo = document.createElement( 'div' );
+        scoreinfo.classList.add( 'skinjson-score-info' );
+        scoreinfo.innerText = improvements.length ? 
+            `Scoring by SkinJSON.\nPossible improvements for ${who}:\n${improvements.join('\n')}` :
+            `Skin passed all tests for ${who}`;
+        scorebox.appendChild( scoreinfo );
+
+        container.appendChild( scorebox );
+        scorebox.addEventListener( 'click', ( ev ) => {
             ev.target.parentNode.removeChild( ev.target );
-        }).appendTo( container );
+        } );
     }
     scoreIt( rules, 'Readers' );
 

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -71,7 +71,7 @@ $(function () {
         }
     };
 
-    function scoreIt( r, who, offset ) {
+    function scoreIt( r, who ) {
         const improvements = [];
         let score = 0;
         Object.keys(r).forEach((rule) => {
@@ -82,26 +82,32 @@ $(function () {
             }
         });
         const grade = scoreToGrade( score, r );
+
+        let container = document.querySelector( '.skinjson-scores' );
+        if ( !container ) {
+            container = document.createElement( 'div' );
+            container.classList.add( 'skinjson-scores' );
+            document.body.appendChild( container );
+        }
+
         $( '<div>' ).addClass(
             `skinjson-score skinjson-score-${grade.label}`
-        ).css( {
-            right: `${((offset*40) + (8 + (8 * offset)))}px`,
-        } ).attr(
+        ).attr(
             'title', 
             improvements.length ?
                 `Scoring by SkinJSON.\nPossible improvements for ${who}:\n${improvements.join('\n')}` :
                 `Skin passed all tests for ${who}`
         ).text( grade.name ).on( 'click', (ev) => {
             ev.target.parentNode.removeChild( ev.target );
-        }).appendTo( document.body );
+        }).appendTo( container );
     }
-    scoreIt( rules, 'Readers', 0 );
+    scoreIt( rules, 'Readers' );
 
     if ( !isAnon ) {
         rulesAdvancedUsers['May not support notifications'] = $( '#pt-notifications-alert' ).length !== 0;
         rulesAdvancedUsers['Supports extensions extending personal tools'] = $(
             '#pt-skin-json-hook-validation-user-menu'
         ).length !== 0;
-        scoreIt( rulesAdvancedUsers, 'Advanced users', 1 );
+        scoreIt( rulesAdvancedUsers, 'Advanced users' );
     }
 });

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -63,11 +63,11 @@ $(function () {
         const name = `${s} / ${total}`;
         const pc = s / total;
         if ( pc > 0.7 ) {
-            return { name, bg: 'green' };
+            return { name, label: 'high' };
         } else if ( pc > 0.5 ) {
-            return { name, bg: 'orange' };
+            return { name, label: 'med' };
         } else {
-            return { name, bg: 'red' };
+            return { name, label: 'low' };
         }
     };
 
@@ -83,10 +83,9 @@ $(function () {
         });
         const grade = scoreToGrade( score, r );
         $( '<div>' ).addClass(
-            'skinjson-score'
+            `skinjson-score skinjson-score-${grade.label}`
         ).css( {
             right: `${((offset*40) + (8 + (8 * offset)))}px`,
-            background: grade.bg,
         } ).attr(
             'title', 
             improvements.length ?

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -82,17 +82,11 @@ $(function () {
             }
         });
         const grade = scoreToGrade( score, r );
-        $( '<div>' ).css( {
-            width: '40px',
-            height: '40px',
-            position: 'fixed',
-            bottom: '8px',
-            textAlign: 'center',
+        $( '<div>' ).addClass(
+            'skinjson-score'
+        ).css( {
             right: `${((offset*40) + (8 + (8 * offset)))}px`,
-            fontSize: '0.7em',
             background: grade.bg,
-            color: 'black',
-            zIndex: 1000
         } ).attr(
             'title', 
             improvements.length ?

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -8,6 +8,7 @@
 }
 
 .skinjson-score {
+	position: relative;
 	width: 40px;
 	height: 40px;
 	font-size: 0.7em;
@@ -26,5 +27,22 @@
 	&-low {
 		background-color: #d33; // WMUI Red 50
 		color: #fff;
+	}
+
+	// Popup
+	&-info {
+		position: absolute;
+    	bottom: 100%;
+    	margin-bottom: 8px;
+    	right: 0;
+    	background: inherit;
+    	width: 200px;
+    	text-align: left;
+    	padding: 8px;
+    	display: none;
+	}
+
+	&:hover &-info {
+		display: block;
 	}
 }

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -1,7 +1,13 @@
-.skinjson-score {
+.skinjson-scores {
 	position: fixed;
 	z-index: 1000;
+	right: 8px;
 	bottom: 8px;
+	display: flex;
+	gap: 8px;
+}
+
+.skinjson-score {
 	width: 40px;
 	height: 40px;
 	font-size: 0.7em;

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -4,7 +4,21 @@
 	bottom: 8px;
 	width: 40px;
 	height: 40px;
-	color: #000;
 	font-size: 0.7em;
 	text-align: center;
+
+	&-high {
+		background-color: #00af89; // WMUI Green 50
+		color: #fff;
+	}
+
+	&-med {
+		background-color: #fc3; // WMUI Yellow 50
+		color: #000;
+	}
+
+	&-low {
+		background-color: #d33; // WMUI Red 50
+		color: #fff;
+	}
 }

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -1,0 +1,10 @@
+.skinjson-score {
+	position: fixed;
+	z-index: 1000;
+	bottom: 8px;
+	width: 40px;
+	height: 40px;
+	color: #000;
+	font-size: 0.7em;
+	text-align: center;
+}


### PR DESCRIPTION
**Problem:**
Currently SkinJson add a score overlay on the bottom right corner. However, it can be confusing as there are no indication of what does the score mean and what added the score box in the first place. The information is hidden in the title attribute of the element, which might not be easily accessible.

**Proposed solution**
Create an popup through hover. It is an interim solution that might also have its accessibility issue, but it will be an improvement.

This patch also decouples inline attributes from the score overlay into stylesheets and other HTML elements.