### PR TITLE
Add simple toggle to toggle SkinJSON elements

### DIFF
--- a/skinValidate.js
+++ b/skinValidate.js
@@ -63,6 +63,33 @@ $(function () {
         rules[`Does not support the ${hook} hook`] = enabledHooks.indexOf( hook ) > -1;
     } );
 
+    const createContainer = () => {
+        const createToggle = () => {
+            const toggle = document.createElement( 'div' );
+
+            // SkinJSON elements are visible by default
+            toggle.classList.add( 'skin-json-toggle' );
+            toggle.setAttribute( 'title', 'Toggle SkinJSON elements' );
+            toggle.textContent = 'off';
+
+            toggle.addEventListener( 'click', ( ev ) => {
+                // Body class use to hide SkinJSON elements in CSS
+                document.body.classList.toggle( 'skin-json--hidden' );
+                ev.target.classList.toggle( 'skin-json-toggle--on' );
+                ev.target.textContent = ev.target.classList.contains( 'skin-json-toggle--on' ) ? 'on' : 'off';
+            } );
+            return toggle;
+        }
+
+        const el = document.createElement( 'div' );
+        el.classList.add( 'skin-json-overlay' );
+        el.appendChild( createToggle() );
+        document.body.appendChild( el );
+        return el;
+    };
+
+    const container = document.querySelector( '.skin-json-overlay' ) ?? createContainer();
+
     const scoreToGrade = (s, r) => {
         const total = Object.keys(r).length;
         const name = `${s} / ${total}`;
@@ -88,22 +115,14 @@ $(function () {
         });
         const grade = scoreToGrade( score, r );
 
-        const createContainer = () => {
-            const el = document.createElement( 'div' );
-            el.classList.add( 'skinjson-scores' );
-            document.body.appendChild( el );
-            return el;
-        };
-        const container = document.querySelector( '.skinjson-scores' ) ?? createContainer();
-
         // NOTE: Maybe this should be put into some kind of template,
         // maybe HTML template tag or Mustache or template literals
         const scorebox = document.createElement( 'div' );
-        scorebox.classList.add( 'skinjson-score', `skinjson-score-${grade.label}` );
+        scorebox.classList.add( 'skin-json-score', `skin-json-score-${grade.label}` );
         scorebox.textContent = grade.name;
 
         const scoreinfo = document.createElement( 'div' );
-        scoreinfo.classList.add( 'skinjson-score-info' );
+        scoreinfo.classList.add( 'skin-json-score-info' );
         scoreinfo.innerText = improvements.length ? 
             `Scoring by SkinJSON.\nPossible improvements for ${who}:\n${improvements.join('\n')}` :
             `Skin passed all tests for ${who}`;
@@ -114,6 +133,7 @@ $(function () {
             ev.target.parentNode.removeChild( ev.target );
         } );
     }
+
     scoreIt( rules, 'Readers' );
 
     if ( !isAnon ) {

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -129,9 +129,6 @@ $(function () {
         scorebox.appendChild( scoreinfo );
 
         container.appendChild( scorebox );
-        scorebox.addEventListener( 'click', ( ev ) => {
-            ev.target.parentNode.removeChild( ev.target );
-        } );
     }
 
     scoreIt( rules, 'Readers' );

--- a/skinValidate.js
+++ b/skinValidate.js
@@ -70,13 +70,13 @@ $(function () {
             // SkinJSON elements are visible by default
             toggle.classList.add( 'skin-json-toggle' );
             toggle.setAttribute( 'title', 'Toggle SkinJSON elements' );
-            toggle.textContent = 'off';
+            toggle.textContent = 'hide';
 
             toggle.addEventListener( 'click', ( ev ) => {
                 // Body class use to hide SkinJSON elements in CSS
                 document.body.classList.toggle( 'skin-json--hidden' );
                 ev.target.classList.toggle( 'skin-json-toggle--on' );
-                ev.target.textContent = ev.target.classList.contains( 'skin-json-toggle--on' ) ? 'on' : 'off';
+                ev.target.textContent = ev.target.classList.contains( 'skin-json-toggle--on' ) ? 'show' : 'hide';
             } );
             return toggle;
         }

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -1,48 +1,79 @@
-.skinjson-scores {
-	position: fixed;
-	z-index: 1000;
-	right: 8px;
-	bottom: 8px;
-	display: flex;
-	gap: 8px;
-}
+.skin-json {
+	&-overlay {
+		position: fixed;
+		z-index: 1000;
+		right: 8px;
+		bottom: 8px;
+		display: flex;
+		flex-direction: row-reverse;
+		gap: 8px;
 
-.skinjson-score {
-	position: relative;
-	width: 40px;
-	height: 40px;
-	font-size: 0.7em;
-	text-align: center;
-
-	&-high {
-		background-color: #00af89; // WMUI Green 50
-		color: #fff;
+		// This is temporary
+		> div {
+			display: grid;
+			width: 40px;
+			height: 40px;
+			cursor: pointer;
+			font-size: 0.7em;
+			place-content: center;
+			user-select: none;
+		}
 	}
 
-	&-med {
-		background-color: #fc3; // WMUI Yellow 50
-		color: #000;
-	}
-
-	&-low {
+	&-toggle {
 		background-color: #d33; // WMUI Red 50
 		color: #fff;
+		text-transform: uppercase;
+
+		&--on {
+			background-color: #00af89; // WMUI Green 50
+			color: #fff;
+		}
 	}
 
-	// Popup
-	&-info {
-		position: absolute;
-    	bottom: 100%;
-    	margin-bottom: 8px;
-    	right: 0;
-    	background: inherit;
-    	width: 200px;
-    	text-align: left;
-    	padding: 8px;
-    	display: none;
+	&-score {
+		position: relative;
+
+		&-high {
+			background-color: #00af89; // WMUI Green 50
+			color: #fff;
+		}
+
+		&-med {
+			background-color: #fc3; // WMUI Yellow 50
+			color: #000;
+		}
+
+		&-low {
+			background-color: #d33; // WMUI Red 50
+			color: #fff;
+		}
+
+		// Popup
+		&-info {
+			position: absolute;
+			right: 0;
+			bottom: 100%;
+			display: none;
+			width: 200px;
+			padding: 8px;
+			margin-bottom: 8px;
+			background: inherit;
+			text-align: left;
+		}
+
+		&:hover &-info {
+			display: block;
+		}
 	}
 
-	&:hover &-info {
-		display: block;
+	// Hide SkinJSON elements
+	&--hidden {
+		.skin-json {
+			&-score,
+			&-validation-element {
+				display: none;
+			}
+		}
 	}
 }


### PR DESCRIPTION
With SkinJSON adding more elements to the debug UI (e.g. de82f64774fbd33b3836662447d47a34f4f0d168), it would be nice to have a toggle that can switch everything to be visible or hidden. This PR will add a simple toggle to do just that. Same with #6, this is intended to be the MVP and the first implementation, refinements will come later.

| Visible  | Hidden |
| ------------- | ------------- |
| ![localhost_8080_wiki_Main_Page_useskin=Vector-2022 (2)](https://user-images.githubusercontent.com/9260542/170837094-0ad83e3e-70b8-4d12-8a92-908ef656309a.png)  | ![localhost_8080_wiki_Main_Page_useskin=Vector-2022 (3)](https://user-images.githubusercontent.com/9260542/170837097-42e9de41-6970-4591-ab47-47c3316b1e20.png)  |