### PR TITLE
Tweak validation element styles and behavior

### DIFF
--- a/SkinJSON.php
+++ b/SkinJSON.php
@@ -139,13 +139,13 @@ class SkinJSON extends SkinMustache {
 		}
 	}
 
-	public static function onSkinAfterPortlet( $skin, $name, &$html ) {
+	public static function onSkinAfterPortlet( $skin, $portlet, &$html ) {
 		$html .= self::hookTestElement(
 			'SkinAfterPortlet',
 			$skin->getConfig(),
 			// only these ones are inline
-			in_array( $name, [ 'navigation', 'namespaces', 'views' ] ),
-			'($name === "' . $name . '")'
+			in_array( $portlet, [ 'navigation', 'namespaces', 'views' ] ),
+			'($portlet === "' . $portlet . '")'
 		);
 	}
 

--- a/SkinJSON.php
+++ b/SkinJSON.php
@@ -106,10 +106,12 @@ class SkinJSON extends SkinMustache {
 	private static function hookTestData( string $hook, Config $config, $inline = true, $note = '' ) {
 		$hookUrl = '//www.mediawiki.org/wiki/Manual:Hooks/' . $hook;
 		if ( $config->get( 'SkinJSONValidate' ) ) {
-			$link = Html::element( 'a', [
-				'href' => $hookUrl,
-				'title' => $note
-			], $hook );
+			$title = Html::element('div', [ 'class' => 'skin-json-validation-element__title' ], $hook );
+			$desc = $note ? Html::element('div', [ 'class' => 'skin-json-validation-element__description' ], $note ) : null;
+			$link = Html::rawElement( 'a', [
+					'href' => $hookUrl,
+					'title' => 'View documentation on MediaWiki.org'
+				], $title . $desc );
 			return [
 				'title' => $note,
 				'class' => [

--- a/SkinJSON.php
+++ b/SkinJSON.php
@@ -173,7 +173,7 @@ class SkinJSON extends SkinMustache {
 			'SidebarBeforeOutput',
 			$skin->getConfig(),
 			true,
-			'(appending to $sidebar["navigation"])'
+			'Append to $sidebar["navigation"]'
 		);
 	}
 

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -1,14 +1,41 @@
 .skin-json {
 	&-validation {
 		&-element {
-			background: #00af89;
-
-			&-block {
-				padding: 20px;
-			}
+			--color-skinjson-surface: #eaddff;
+			--color-skinjson-surface--hover: #f6edff;
+			--color-skinjson-surface--active: #d0bcff;
+			--color-skinjson-text: #21005d;
 
 			a {
-				color: #fff;
+				display: block;
+				padding: 0.75rem 1rem;
+				background: var( --color-skinjson-surface );
+				font-size: 0.8125rem;
+				line-height: 1.25;
+				text-align: start;
+				text-decoration: none;
+
+				&:hover {
+					// So user can see it even when it is under another element
+					position: relative;
+					z-index: 1;
+					background: var( --color-skinjson-surface--hover );
+				}
+
+				&:active {
+					background: var( --color-skinjson-surface--active );
+				}
+			}
+
+			&__title {
+				color: var( --color-skinjson-text );
+				font-family: 'Menlo', 'Consolas', 'Liberation Mono', 'Courier New', monospace; // WMUI monospace fonts
+				font-size: 0.875rem;
+				font-weight: bold;
+			}
+
+			&__description {
+				color: #222;
 			}
 		}
 	}
@@ -90,13 +117,7 @@
 			}
 
 			&-validation-element {
-				&-block {
-					display: block;
-				}
-
-				&-inline {
-					display: inline-block;
-				}
+				display: revert;
 			}
 		}
 	}

--- a/skinValidate.less
+++ b/skinValidate.less
@@ -18,7 +18,7 @@
 				&:hover {
 					// So user can see it even when it is under another element
 					position: relative;
-					z-index: 1;
+					z-index: 101; // High enough that it is always at the top
 					background: var( --color-skinjson-surface--hover );
 				}
 


### PR DESCRIPTION
- Differentiate SkinJSON elements with other parts of the wiki to reduce confusions
  - Use purple as primary color as it is rarely used by core and extensions
  - Use monospace font for title to hint that it is development-related
- Show notes inside the element to increase discoverability
- Title is now replaced by the message 'View documentation on MediaWiki.org` to correctly label the link element
- Hovering on the element will now raise its z-index, making it visible to user when it is behind other elements
- Rename `$name` to `$portlet` as it is what is used in MW core

**Screeenshot:**
| Vector  | Minerva |
| ------------- | ------------- |
| ![localhost_8080_wiki_Lorum_ipsum (4)](https://user-images.githubusercontent.com/9260542/176579365-1ed32cee-5f66-4ff5-b1ba-faa78f6607ce.png) | ![localhost_8080_wiki_Lorum_ipsum_useskin=minerva](https://user-images.githubusercontent.com/9260542/176579374-5f82481f-c22e-479b-806b-1417d8e9772c.png) |