### PR TITLE
Add custom SkinJSON preview type

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -1,12 +1,19 @@
 {
 	"name": "SkinJson",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"author": "Jon Robson",
+	"type": "skin",
 	"url": "https://github.com/jdlrobson/mediawiki-skins-skinjson",
 	"descriptionmsg": "skinjson-desc",
 	"namemsg": "skinname-skinjson",
 	"license-name": "CC0-1.0",
-	"type": "skin",
+	"attributes": {
+		"Popups": {
+			"PluginModules": [
+				"skins.skinjson.popup"
+			]
+		}
+	},
 	"requires": {
 		"MediaWiki": ">= 1.38.0"
 	},
@@ -41,6 +48,11 @@
 		"skins.skinjson.debug": {
 			"es6": true,
 			"scripts": [ "skindebug.js" ],
+			"targets": [ "desktop", "mobile" ]
+		},
+		"skins.skinjson.popup": {
+			"es6": true,
+			"scripts": [ "skinpopup.js" ],
 			"targets": [ "desktop", "mobile" ]
 		},
 		"skins.skinjson": {

--- a/skindebug.css
+++ b/skindebug.css
@@ -1,3 +1,19 @@
 /* will be exposed by banner */
 #pt-skin-json-hook-validation-user-menu,
+.skin-json-validation-element__description,
 .xdebug-error { display: none; }
+
+.skin-json-hook-validation-element a {
+	position: relative;
+}
+
+.skin-json-validation-element__title {
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	opacity: 0;
+}

--- a/skinpopup.js
+++ b/skinpopup.js
@@ -1,0 +1,44 @@
+const type = 'skinjson-tooltip';
+
+const fetchPreviewForTitle = ( title, el ) => {
+	const deferred = $.Deferred();
+	const hook = el.dataset.hook;
+	const info = el.dataset.info;
+	const url = `https://www.mediawiki.org/wiki/Manual:Hooks/${hook}`;
+	let code = info ? `<p>Use the following check inside the hook body: <pre>${info}</pre>.</p>` : '';
+	deferred.resolve( {
+		title: 'Hello world',
+		extract: [
+			`<p>Modifications to this part of the skin can be made using the <strong><a href="${url}">${hook}</a></strong> hook.</p>
+			${code}`
+		],
+		url,
+		type,
+		languageCode: 'en',
+		languageDirection: 'ltr',
+		thumbnail: undefined,
+		pageId: -1
+	} );
+	return deferred;
+};
+
+// hide all descriptions
+document.querySelectorAll( '.skin-json-validation-element__description' ).forEach( ( node ) => {
+	const prev = node.previousElementSibling;
+	if ( prev.classList.contains( 'skin-json-validation-element__title' ) ) {
+		prev.dataset.info = node.textContent;
+		node.parentNode.removeChild( node );
+	}
+} );
+document.querySelectorAll( '.skin-json-validation-element__title' ).forEach( ( node ) => {
+	node.dataset.hook = node.textContent;
+	node.textContent = '';
+} );
+
+module.exports = {
+	type,
+	selector: '.skin-json-validation-element__title',
+	gateway: {
+		fetchPreviewForTitle
+	}
+};


### PR DESCRIPTION
When $wgSkinJSONDebug = true; and the hints are toggled (using control in bottom right) show previews when these areas are hovered over

Change-Id: I13073f4552181d3ebf8fb05d9283b2dec5ea424d
![Screen Shot 2022-10-18 at 5 40 21 PM](https://user-images.githubusercontent.com/148752/196570801-7b89d7e9-b3fd-4cef-ac56-fcc50beacb98.png)


Requires: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Popups/+/813347