### PR TITLE
WIP: Explore API instead of skin

### DIFF
--- a/SkinJSON.php
+++ b/SkinJSON.php
@@ -227,6 +227,17 @@ class SkinJSON extends SkinMustache {
 		return $reqSkinKey && $format === 'json';
 	}
 
+	private function setSkinContext( $skin, $title = '' ) {
+		$fauxContext = $skin->getContext();
+		$out = new OutputPage( new RequestContext() );
+		$out->enableOOUI();
+		$fauxContext->setOutput( $out );
+		if ( $title ) {
+			$fauxContext->setTitle( Title::newFromText( $title ) );
+		}
+		$skin->setContext( $fauxContext );
+	}
+
 	/**
 	 * Attempt a basic render of the skin and collect some meta
 	 * data based on what happens.
@@ -241,13 +252,7 @@ class SkinJSON extends SkinMustache {
 		try {
 			error_reporting( -1 );
 			ini_set( 'display_errors', -1 );
-			$fauxContext = $skin->getContext();
-			$out = new OutputPage( new RequestContext() );
-			$out->enableOOUI();
-			$fauxContext->setOutput( $out );
-			$fauxContext->setTitle( Title::newFromText( 'Special:BlankPage' ) );
-			$skin->setContext( $fauxContext );
-
+			$this->setSkinContext( $skin );
 			$then = microtime( true );
 			$html = $skin->generateHTML();
 			$warnings = ob_get_contents();

--- a/includes/Handler.php
+++ b/includes/Handler.php
@@ -6,6 +6,7 @@ use ExtensionRegistry;
 use MediaWiki\Rest;
 use MediaWiki\MediaWikiServices;
 use SkinJSON;
+use Title;
 use Wikimedia\ParamValidator\ParamValidator;
 
 /**
@@ -23,6 +24,16 @@ class Handler extends Rest\Handler {
 
 	public function getParamSettings() {
 		return [
+			'name' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false
+			],
+			'title' => [
+				self::PARAM_SOURCE => 'path',
+				ParamValidator::PARAM_TYPE => 'string',
+				ParamValidator::PARAM_REQUIRED => false
+			],
 			'experimental' => [
 				ParamValidator::PARAM_TYPE => 'boolean',
 				ParamValidator::PARAM_REQUIRED => false,
@@ -73,17 +84,38 @@ class Handler extends Rest\Handler {
 		return $meta;
 	}
 
+	private function generateSkinJSON( $name, $title ) {
+		$services = MediaWikiServices::getInstance();
+		$factory = $services->getSkinFactory();
+
+		$skin = $factory->makeSkin( $name );
+		$ctx = $skin->getContext();
+		$out = $skin->getOutput();
+		if ( !$title ) {
+			$title = 'Main_Page';
+		}
+		$t = Title::newFromText( $title );
+		$out->setTitle( $t );
+		$ctx->setOutput( $out );
+		$skin->setContext( $ctx );
+		return $skin->getTemplateData();
+	}
+
 	/**
 	 * @return Response
 	 * @throws LocalizedHttpException
 	 */
 	public function execute() {
-		$services = MediaWikiServices::getInstance();
+		$request = $this->getRequest();
+		$name = $request->getPathParam( 'name' );
+		$json = $name ? $this->generateSkinJSON( $name, $request->getPathParam( 'title' ) ) : $this->getResponseJSON();
 		$response = $this->getResponseFactory()->createJson(
-			$this->getResponseJSON()
+			$json
 		);
+		$response->setStatus( 200 );
 		$response->setHeader( 'Access-Control-Allow-Origin', '*' );
 		$response->setHeader( 'Cache-Control', 'no-store, max-age=0' );
+		$response->setHeader( 'Content-Type', 'application/json' );
 		return $response;
 	}
 

--- a/restRoutes.json
+++ b/restRoutes.json
@@ -3,5 +3,15 @@
 		"path": "/v1/skins",
 		"class": "SkinJSON\\Handler",
 		"services": []
+	},
+	{
+		"path": "/v1/skins/{name}",
+		"class": "SkinJSON\\Handler",
+		"services": []
+	},
+	{
+		"path": "/v1/skins/{name}/{title}",
+		"class": "SkinJSON\\Handler",
+		"services": []
 	}
 ]


### PR DESCRIPTION
In future it might not be possible for skins to render as JSON. If that happens this will need to be converted to an API.

Currently this doesn't seem to work
The title and body HTML for http://localhost:8888/w/rest.php/v1/skins/vector-2022/Paris are not being generated.